### PR TITLE
Fixes to work with Node-RED 0.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Run the following command in your node-RED user directory (typically `~/.node-re
 
 ## Content
 
-openpcs_read:   node to read data from OpenPCS (OpenPCS -> Node-RED)
-openpcs_write:  node to write data to OpenPCS (Node-RED -> OpenPCS)
+- *openpcs_read*:   node to read data from OpenPCS (OpenPCS -> Node-RED)
+- *openpcs_write*:  node to write data to OpenPCS (Node-RED -> OpenPCS)
 
 
 ## Node status

--- a/openpcs_write.js
+++ b/openpcs_write.js
@@ -25,6 +25,7 @@
   Revision History:
 
   2018/04/02 -rs:   V1.00 Initial version
+  2019/03/20 -ad:   V1.01 Fix handling for initial value
 
 ****************************************************************************/
 
@@ -45,7 +46,6 @@ module.exports = function(RED)
     //  Import external modules
     //=======================================================================
 
-    const RedRuntimeEvents = require('/usr/lib/node_modules/node-red/red/runtime/events');
     const Ipc = require('./ipcclient.js');
 
 
@@ -111,8 +111,11 @@ module.exports = function(RED)
         // register handler for event type 'close'
         ThisNode.on ('close', OpenPCS_Write_NodeHandler_OnClose);
 
-        // register one-time handler for event type 'nodes-started'
-        RedRuntimeEvents.once ('nodes-started', OpenPCS_Write_NodeHandler_OnNodesStarted);
+        // register one-time handler for sending the initial value
+        ThisNode.m_injectImmediate = setImmediate(function()
+        {
+            OpenPCS_Write_NodeHandler_OnNodesStarted();
+        });
 
         // run handler for event type 'open'
         OpenPCS_Write_NodeHandler_OnOpen (NodeConfig_p);
@@ -282,6 +285,12 @@ module.exports = function(RED)
         {
 
             TraceMsg ('{OpenPCS_Write_Node} closing...');
+
+            // clear immediate timeout
+            if (ThisNode.m_injectImmediate)
+            {
+                clearImmediate(ThisNode.m_injectImmediate);
+            }
 
             // cancel possibly running status timer
             if ( ThisNode.m_ObjStatusTimer )

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ref-array": "1.2.0",
     "ref-struct": "1.1.0"
   },
-  "keywords": [ 
+  "keywords": [
     "sysworxx",
     "ctr700",
     "node-red"
@@ -27,4 +27,3 @@
     }
   }
 }
-


### PR DESCRIPTION
The following modules cannot be used anymore:
`const RedRuntimeEvents = require("/usr/lib/node_modules/node-red/red/runtime/events");`
The patches fixes errors caused by using this.